### PR TITLE
feat/modern-compilers

### DIFF
--- a/src/seqan/file/file_format.h
+++ b/src/seqan/file/file_format.h
@@ -205,27 +205,27 @@ public:
 	~FileFormat() {}
 	FileFormat const & operator =(FileFormat const &) { return *this; }
 
-	virtual void *
-	formatID_() const = 0;
+	void *
+	formatID_();
 
-	virtual void
-	read_(TFile & file, TData & data) const = 0;
-	virtual void
-	read_(TFile & file, TData & data, TSize limit) const = 0;
+	void
+	read_(TFile & file, TData & data);
+	void
+	read_(TFile & file, TData & data, TSize limit);
 
-	virtual void
-	readMeta_(TFile & file, TMeta & meta) const = 0;
+	void
+	readMeta_(TFile & file, TMeta & meta);
 
-	virtual void
-	goNext_(TFile & file) const = 0;
+	void
+	goNext_(TFile & file);
 
-	virtual TSize
-	length_(TFile & file) const = 0;
+	TSize
+	length_(TFile & file);
 
-	virtual void
-	write_(TFile & file, TData & data) const = 0;
-	virtual void
-	write_(TFile & file, TData & data, TMeta & meta) const = 0;
+	void
+	write_(TFile & file, TData & data);
+	void
+	write_(TFile & file, TData & data, TMeta & meta);
 
 };
 

--- a/src/seqan/parallel/parallel_generated_forwards.h
+++ b/src/seqan/parallel/parallel_generated_forwards.h
@@ -57,7 +57,7 @@ namespace seqan {
 //____________________________________________________________________________
 // computeSplitters
 
-template <typename TPos, typename TSize, typename TCount> void computeSplitters(String<TPos> & splitters, TSize size, TCount count);       	// "/Users/fabianbuske/Documents/research/triplex/seqan/core/include/seqan/parallel/parallel_splitting.h"(64)
+template <typename TPosString, typename TSize, typename TCount> void computeSplitters(TPosString & splitters, TSize size, TCount count);       	// "/Users/fabianbuske/Documents/research/triplex/seqan/core/include/seqan/parallel/parallel_splitting.h"(64)
 
 } //namespace seqan
 

--- a/src/seqan/parallel/parallel_splitting.h
+++ b/src/seqan/parallel/parallel_splitting.h
@@ -59,9 +59,11 @@ computeSplitters(splitters, 10, 5);
 ..include:seqan/parallel.h
  */
 
-template <typename TPos, typename TSize, typename TCount>
-void computeSplitters(String<TPos> & splitters, TSize size, TCount count)
+template <typename TPosString, typename TSize, typename TCount>
+void computeSplitters(TPosString & splitters, TSize size, TCount count)
 {
+    typedef typename Value<TPosString>::Type TPos;
+
     resize(splitters, count + 1);
     splitters[0] = 0;
     TSize blockLength = size / count;

--- a/src/triplexator.cpp
+++ b/src/triplexator.cpp
@@ -917,7 +917,7 @@ namespace SEQAN_NAMESPACE_MAIN
 			appendValue(duplexNames, id, Generous());
 			
 			read(file, duplexString, Fasta());			// read Fasta sequence
-			ttsnoToFileMap.insert(::std::make_pair<unsigned,::std::pair< ::std::string,unsigned> >(seqNo,::std::make_pair< ::std::string,unsigned>(filename,seqNoWithinFile)));
+			ttsnoToFileMap.insert(::std::make_pair<unsigned,::std::pair< ::std::string,unsigned> >(::std::move(seqNo),::std::make_pair< ::std::string,unsigned>(::std::move(filename),::std::move(seqNoWithinFile))));
 			
 			if (options._debugLevel > 1 )
 				options.logFileHandle << _getTimeStamp() << "   ... Finished reading next duplex sequence" << ::std::endl;
@@ -1040,7 +1040,7 @@ namespace SEQAN_NAMESPACE_MAIN
 			readShortID(file, id, Fasta());			// read Fasta id up to first whitespace
 			appendValue(duplexNames, id, Generous());
 			read(file, duplexString, Fasta());		// read Fasta sequence
-			ttsnoToFileMap.insert(::std::make_pair<unsigned,::std::pair< ::std::string,unsigned> >(seqNo,::std::make_pair< ::std::string,unsigned>(filename,seqNoWithinFile)));
+			ttsnoToFileMap.insert(::std::make_pair<unsigned,::std::pair< ::std::string,unsigned> >(::std::move(seqNo),::std::make_pair< ::std::string,unsigned>(::std::move(filename),::std::move(seqNoWithinFile))));
 			appendValue(duplexSet, duplexString);	
 			
 			if (options._debugLevel > 1 )


### PR DESCRIPTION
Minimum set of changes to Triplexator to be able to compile the application with modern C++ compilers (supports `-std=c++11` and `-std=c++14`).